### PR TITLE
Centralize plugin version metadata

### DIFF
--- a/geovita_processing_plugin/__init__.py
+++ b/geovita_processing_plugin/__init__.py
@@ -27,40 +27,72 @@ __date__ = '2024-01-17'
 __copyright__ = '(C) 2024 by DPE'
 
 import sys
+import configparser
 from pathlib import Path
 from importlib import metadata
 
 
 PACKAGE_NAME = 'geovita-processing-plugin'
 _FALLBACK_VERSION = '0.0.0'
+_PLUGIN_DIR = Path(__file__).resolve().parent
+_PYPROJECT_CANDIDATES = (
+    _PLUGIN_DIR / 'pyproject.toml',
+    _PLUGIN_DIR.parent / 'pyproject.toml',
+)
+_METADATA_FILE = _PLUGIN_DIR / 'metadata.txt'
 
 
-def _read_version_from_pyproject() -> str:
+def _read_version_from_pyproject() -> str | None:
+    """Return the version declared in pyproject.toml if available."""
+
     try:
         import tomllib  # type: ignore[attr-defined]
-    except ModuleNotFoundError:
+    except ModuleNotFoundError:  # pragma: no cover - only on Python <3.11 without tomli
         try:
             import tomli as tomllib  # type: ignore[no-redef]
         except ModuleNotFoundError:
-            return _FALLBACK_VERSION
+            return None
 
-    plugin_dir = Path(__file__).resolve().parent
-    candidates = [
-        plugin_dir / 'pyproject.toml',
-        plugin_dir.parent / 'pyproject.toml',
-    ]
-    for candidate in candidates:
-        if candidate.is_file():
-            with candidate.open('rb') as fh:
-                data = tomllib.load(fh)
-            return data.get('project', {}).get('version', _FALLBACK_VERSION)
+    for candidate in _PYPROJECT_CANDIDATES:
+        if not candidate.is_file():
+            continue
+        with candidate.open('rb') as fh:
+            data = tomllib.load(fh)
+        return data.get('project', {}).get('version')
+    return None
+
+
+def _read_version_from_metadata() -> str | None:
+    """Return the version declared in metadata.txt if available."""
+
+    if not _METADATA_FILE.is_file():
+        return None
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(_METADATA_FILE, encoding='utf-8')
+    try:
+        return parser.get('general', 'version')
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        return None
+
+
+def _determine_version() -> str:
+    """Resolve the plugin version from packaging metadata or local files."""
+
+    try:
+        return metadata.version(PACKAGE_NAME)
+    except metadata.PackageNotFoundError:  # type: ignore[attr-defined]
+        pass
+
+    for reader in (_read_version_from_pyproject, _read_version_from_metadata):
+        version = reader()
+        if version:
+            return version
     return _FALLBACK_VERSION
 
 
-try:
-    __version__ = metadata.version(PACKAGE_NAME)
-except metadata.PackageNotFoundError:  # type: ignore[attr-defined]
-    __version__ = _read_version_from_pyproject()
+__version__ = _determine_version()
 
 
 # noinspection PyPep8Naming

--- a/geovita_processing_plugin/__init__.py
+++ b/geovita_processing_plugin/__init__.py
@@ -26,10 +26,41 @@ __author__ = 'DPE'
 __date__ = '2024-01-17'
 __copyright__ = '(C) 2024 by DPE'
 
-__version__ = "3.2.2"
-
 import sys
 from pathlib import Path
+from importlib import metadata
+
+
+PACKAGE_NAME = 'geovita-processing-plugin'
+_FALLBACK_VERSION = '0.0.0'
+
+
+def _read_version_from_pyproject() -> str:
+    try:
+        import tomllib  # type: ignore[attr-defined]
+    except ModuleNotFoundError:
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ModuleNotFoundError:
+            return _FALLBACK_VERSION
+
+    plugin_dir = Path(__file__).resolve().parent
+    candidates = [
+        plugin_dir / 'pyproject.toml',
+        plugin_dir.parent / 'pyproject.toml',
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            with candidate.open('rb') as fh:
+                data = tomllib.load(fh)
+            return data.get('project', {}).get('version', _FALLBACK_VERSION)
+    return _FALLBACK_VERSION
+
+
+try:
+    __version__ = metadata.version(PACKAGE_NAME)
+except metadata.PackageNotFoundError:  # type: ignore[attr-defined]
+    __version__ = _read_version_from_pyproject()
 
 
 # noinspection PyPep8Naming

--- a/geovita_processing_plugin/test/test_version_sync.py
+++ b/geovita_processing_plugin/test/test_version_sync.py
@@ -1,0 +1,38 @@
+"""Tests ensuring version consistency across metadata sources."""
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+import geovita_processing_plugin as plugin
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
+METADATA_FILE = REPO_ROOT / "geovita_processing_plugin" / "metadata.txt"
+
+
+def read_version_from_pyproject() -> str:
+    with PYPROJECT_FILE.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data["project"]["version"]
+
+
+def read_version_from_metadata() -> str:
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(METADATA_FILE)
+    return parser.get("general", "version")
+
+
+def test_package_version_matches_pyproject():
+    assert plugin.__version__ == read_version_from_pyproject()
+
+
+def test_metadata_version_matches_pyproject():
+    assert read_version_from_metadata() == read_version_from_pyproject()

--- a/geovita_processing_plugin/test/test_version_sync.py
+++ b/geovita_processing_plugin/test/test_version_sync.py
@@ -36,3 +36,7 @@ def test_package_version_matches_pyproject():
 
 def test_metadata_version_matches_pyproject():
     assert read_version_from_metadata() == read_version_from_pyproject()
+
+
+def test_package_version_matches_metadata():
+    assert plugin.__version__ == read_version_from_metadata()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "geovita-processing-plugin"
+version = "3.2.2"
+description = "Geovita GIS Processing provider for QGIS"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+    { name = "DPE", email = "dpe@geovita.no" }
+]
+license = { file = "LICENSE" }
+classifiers = [
+    "Programming Language :: Python",
+    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+    "Framework :: QGIS"
+]
+dynamic = ["dependencies"]
+
+[tool.geovita]
+metadata-file = "geovita_processing_plugin/metadata.txt"

--- a/scripts/update_metadata_version.py
+++ b/scripts/update_metadata_version.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Synchronise metadata.txt version with pyproject.toml."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
+METADATA_FILE = REPO_ROOT / "geovita_processing_plugin" / "metadata.txt"
+VERSION_PATTERN = re.compile(r"^(version\s*=\s*)(.+)$", re.MULTILINE)
+
+
+class MetadataVersionError(RuntimeError):
+    """Raised when metadata synchronisation cannot be completed."""
+
+
+def read_version_from_pyproject() -> str:
+    if not PYPROJECT_FILE.is_file():
+        raise MetadataVersionError(f"Missing pyproject: {PYPROJECT_FILE}")
+
+    with PYPROJECT_FILE.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    project = data.get("project")
+    if not project or "version" not in project:
+        raise MetadataVersionError("[project] table missing version")
+
+    return project["version"]
+
+
+def update_metadata_version(new_version: str) -> None:
+    if not METADATA_FILE.is_file():
+        raise MetadataVersionError(f"Missing metadata file: {METADATA_FILE}")
+
+    contents = METADATA_FILE.read_text(encoding="utf-8")
+    if "[general]" not in contents:
+        raise MetadataVersionError("metadata.txt lacks [general] section")
+
+    if "version=" not in contents:
+        raise MetadataVersionError("metadata.txt lacks version entry")
+
+    def _replace(match: re.Match[str]) -> str:
+        return f"{match.group(1)}{new_version}"
+
+    updated, count = VERSION_PATTERN.subn(_replace, contents, count=1)
+    if count != 1:
+        raise MetadataVersionError("Unexpected number of version entries updated")
+
+    METADATA_FILE.write_text(updated, encoding="utf-8")
+
+
+def main() -> None:
+    version = read_version_from_pyproject()
+    update_metadata_version(version)
+    print(f"Updated metadata version to {version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` that records the canonical plugin version
- update the plugin package `__init__` to read the version from packaging metadata or the pyproject fallback
- add a helper script and tests to keep `metadata.txt` in sync with the declared version

## Testing
- pytest geovita_processing_plugin/test/test_version_sync.py *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_b_690b68ddfeec832f91a6bba6db8112fd